### PR TITLE
Fix : ajout de props éditables

### DIFF
--- a/WEB-INF/plugins/SEOPlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SEOPlugin/properties/languages/fr.prop
@@ -1,5 +1,7 @@
 jcmsplugin.seo.sitemap.content.blacklist: Liste noire de types à exclure pour le sitemap
 plugin.seo.gtm.id: ID du marqueur Google Tag Manager
+fr.jcmsplugin.seo.meta-description: Meta description FR
+en.jcmsplugin.seo.meta-description: Meta description EN 
 
 # ------------------------------------------------------------
 #  Pages d'erreur

--- a/WEB-INF/plugins/SEOPlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SEOPlugin/properties/plugin.prop
@@ -54,6 +54,8 @@ jcmsplugin.seo.sitemap.content.blacklist:
 plugin.seo.fullPage.content.blacklist:
 plugin.seo.category.navigation.id: c_5025
 plugin.seo.portal.fullDisplay.id: c_1088637
+fr.jcmsplugin.seo.meta-description.area: 
+en.jcmsplugin.seo.meta-description.area: 
 
 # ------------------------------------------------------------
 #  Analytics


### PR DESCRIPTION
Pour gérer la meta-description générique en FR et EN, ajout de propriétés éditables.
Dans les props du site (espace d'admin), il n'est en effet pas possible de saisir une description multilingue mais seulement en FR.