### PR TITLE
Evol : titres de pages customisés (1915 / 1936)

### DIFF
--- a/WEB-INF/plugins/SEOPlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SEOPlugin/properties/languages/fr.prop
@@ -3,7 +3,11 @@ plugin.seo.gtm.id: ID du marqueur Google Tag Manager
 fr.jcmsplugin.seo.meta-description: Meta description FR
 fr.jcmsplugin.seo.meta-description.help: Meta description générique qui apparaitra si elle n'a pas été surchargée au niveau des contenus
 en.jcmsplugin.seo.meta-description: Meta description EN
-en.jcmsplugin.seo.meta-description.help: Meta description générique qui apparaitra si elle n'a pas été surchargée au niveau des contenus  
+en.jcmsplugin.seo.meta-description.help: Meta description générique qui apparaitra si elle n'a pas été surchargée au niveau des contenus
+fr.jcmsplugin.seo.meta-title: Nom du site FR
+fr.jcmsplugin.seo.meta-title.help: Sert de suffixe dans les titres de pages (balise "title")
+en.jcmsplugin.seo.meta-title: Nom du site EN  
+en.jcmsplugin.seo.meta-title.help: Sert de suffixe dans les titres de pages (balise "title")
 
 # ------------------------------------------------------------
 #  Pages d'erreur

--- a/WEB-INF/plugins/SEOPlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SEOPlugin/properties/plugin.prop
@@ -55,7 +55,9 @@ plugin.seo.fullPage.content.blacklist:
 plugin.seo.category.navigation.id: c_5025
 plugin.seo.portal.fullDisplay.id: c_1088637
 fr.jcmsplugin.seo.meta-description.area: 
-en.jcmsplugin.seo.meta-description.area: 
+en.jcmsplugin.seo.meta-description.area:
+fr.jcmsplugin.seo.meta-title: 
+en.jcmsplugin.seo.meta-title:  
 
 # ------------------------------------------------------------
 #  Analytics


### PR DESCRIPTION
Prévoir un suffixe personnalisé pour les titres de pages, à la place du channel.name