### PR TITLE
hotfix : calcul catégorie courante

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/seo/policyfilter/SEOPortalPolicyFilter.java
+++ b/WEB-INF/classes/fr/cg44/plugin/seo/policyfilter/SEOPortalPolicyFilter.java
@@ -192,24 +192,20 @@ public class SEOPortalPolicyFilter extends BasicPortalPolicyFilter {
 
     String categoryString = HttpUtil.getUntrustedStringParameter(channel.getCurrentServletRequest(), CATEGORY_PARAMETER, null);
 
+    if (Util.isEmpty(categoryString)) {
+      return;
+    }
+
     Category currentCategory = channel.getCategory(categoryString);
 
     if (Util.notEmpty(currentCategory)) {
       context.setCurrentCategory(currentCategory);
       return;
     }
-    
-    // Permet d'avoir la catégorie de l'url en catégorie courante 
-    Category urlCat = SEOUtils.getURLCategory(context.getPublication()); 
-    if(Util.notEmpty(urlCat)) { 
-      context.setCurrentCategory(urlCat); 
-      return; 
-    } 
 
-    if (Util.notEmpty(categoryString)) {
-      logger.warn(" The category with id : " + categoryString + " has been forced but this category not exists. Referer : "
-          + ServletUtil.getUrl(channel.getCurrentJcmsContext().getRequest()));
-    }
+    logger.warn(" The category with id : " + categoryString + " has been forced but this category not exists. Referer : "
+        + ServletUtil.getUrl(channel.getCurrentJcmsContext().getRequest()));
+
   }
   
 


### PR DESCRIPTION
Régression signalée dans menu de navigation des pages carrefour.
On revient sur l'ancienne version de la méthode en attendant une correction.